### PR TITLE
bug: bip32 trait used Bip32Error instead of Self::Error

### DIFF
--- a/bip32/src/curve/model.rs
+++ b/bip32/src/curve/model.rs
@@ -200,5 +200,5 @@ pub trait Secp256k1Backend: Clone + std::fmt::Debug + PartialEq {
         &self,
         digest: [u8; 32],
         sig: &Self::RecoverableSignature,
-    ) -> Result<Self::Pubkey, Bip32Error>;
+    ) -> Result<Self::Pubkey, Self::Error>;
 }

--- a/bip32/src/keys.rs
+++ b/bip32/src/keys.rs
@@ -82,7 +82,7 @@ impl<'a, T: Secp256k1Backend> GenericPubkey<'a, T> {
         sig: &T::RecoverableSignature,
     ) -> Result<Self, Bip32Error> {
         Ok(Self {
-            key: backend.recover_pubkey(digest, sig)?,
+            key: backend.recover_pubkey(digest, sig).map_err(Into::into)?,
             backend: Some(backend),
         })
     }

--- a/bitcoins/src/types/txin.rs
+++ b/bitcoins/src/types/txin.rs
@@ -198,8 +198,8 @@ pub type BitcoinOutpoint = Outpoint<TXID>;
 /// A simple type alias for an input type that will be repeated throughout the `bitcoin` module.
 pub type BitcoinTxIn = TxInput<TXID>;
 
-/// Vin is a type alias for `Vec<TxInput>`. A transaction's Vin is the Vector of
-/// INputs, with a length prefix.
+/// Vin is a type alias for `Vec<TxInput>`. A transaction's Vin is the Vector of INputs, with a
+/// length prefix.
 pub type Vin = Vec<BitcoinTxIn>;
 
 #[cfg(test)]


### PR DESCRIPTION
Cleans up the Bip32 backend trait