### PR TITLE
bitcoins: remove dead code from TxError enum

### DIFF
--- a/bitcoins/src/types/tx.rs
+++ b/bitcoins/src/types/tx.rs
@@ -227,9 +227,6 @@ pub enum TxError {
     /// Wrong sighash args passed in to wrapped tx
     #[error("Sighash args must match the wrapped tx type")]
     WrongSighashArgs,
-    // /// No outputs in vout
-    // #[error("Vout may not be empty")]
-    // EmptyVout
 }
 
 /// Type alias for result with TxError


### PR DESCRIPTION
Removes an unused enum member from `TxError` that isn't referenced anywhere else in the codebase.

```bash
$ grep -rin EmptyVout **/src

```

