### PR TITLE
bitcoins: fix some typos

### DIFF
--- a/bitcoins/src/builder.rs
+++ b/bitcoins/src/builder.rs
@@ -51,11 +51,11 @@ where
     T: BitcoinEncoderMarker,
 {
     /// Add a set of witnesses to the transaction, and return a witness builder.
-    pub fn extend_witnesses<I>(mut self, outputs: I) -> Self
+    pub fn extend_witnesses<I>(mut self, witnesses: I) -> Self
     where
         I: IntoIterator<Item = Witness>,
     {
-        self.witnesses.extend(outputs);
+        self.witnesses.extend(witnesses);
         self
     }
 

--- a/bitcoins/src/hashes.rs
+++ b/bitcoins/src/hashes.rs
@@ -15,7 +15,7 @@ mark_hash256!(
 );
 
 mark_hash256!(
-    /// A marked Hash256Digest representing witness transaction IDs
+    /// A marked Hash256Digest representing a block hash
     BlockHash
 );
 


### PR DESCRIPTION
I built the docs and noticed these typos