### PR TITLE
chores: #53 - macros to core. fix bip32 bench. fix wasm-pack

### DIFF
--- a/bip32/benches/bench.rs
+++ b/bip32/benches/bench.rs
@@ -1,7 +1,7 @@
-use coins_bip32::{curve::model::*, model::*, xkeys::XPriv, Secp256k1};
+use coins_bip32::{prelude::*, primitives::Hint, xkeys::GenericXPriv};
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn derive_10_times(key: &XPriv) {
+fn derive_10_times(key: &GenericXPriv<Secp256k1>) {
     let path: [u32; 10] = [
         0,
         1,
@@ -18,9 +18,8 @@ fn derive_10_times(key: &XPriv) {
 }
 
 pub fn bench_10(c: &mut Criterion) {
-    let backend = Secp256k1::init();
     let seed: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-    let xpriv = XPriv::root_from_seed(&seed, Some(Hint::Legacy), &backend).unwrap();
+    let xpriv = GenericXPriv::root_from_seed(&seed, Some(Hint::Legacy)).unwrap();
 
     c.bench_function("derive_10", |b| b.iter(|| derive_10_times(&xpriv)));
 }

--- a/bip32/src/derived.rs
+++ b/bip32/src/derived.rs
@@ -406,7 +406,9 @@ mod test {
             buf[..5].copy_from_slice(&digest[..5]);
             Hash256Digest::from(buf)
         };
-        let sig = key.sign_with_hash(&digest.as_ref()[..], &hash_func).unwrap();
+        let sig = key
+            .sign_with_hash(&digest.as_ref()[..], &hash_func)
+            .unwrap();
         key_pub
             .verify_with_hash(&digest.as_ref()[..], &hash_func, &sig)
             .unwrap();
@@ -430,7 +432,8 @@ mod test {
             .verify_recoverable_with_hash(&digest.as_ref()[..], &hash_func, &sig)
             .unwrap();
 
-        let err_bad_sig = key_pub.verify_recoverable_with_hash(&wrong_digest.as_ref()[..], &hash_func, &sig);
+        let err_bad_sig =
+            key_pub.verify_recoverable_with_hash(&wrong_digest.as_ref()[..], &hash_func, &sig);
         match err_bad_sig {
             Err(Bip32Error::BackendError(_)) => {}
             _ => assert!(false, "expected signature validation error"),
@@ -448,7 +451,9 @@ mod test {
 
         // sign_recoverable + verify_recoverable
         let sig = key.sign_recoverable(&digest.as_ref()[..]).unwrap();
-        key_pub.verify_recoverable(&digest.as_ref()[..], &sig).unwrap();
+        key_pub
+            .verify_recoverable(&digest.as_ref()[..], &sig)
+            .unwrap();
 
         let err_bad_sig = key_pub.verify_recoverable(&wrong_digest.as_ref()[..], &sig);
         match err_bad_sig {
@@ -518,8 +523,12 @@ mod test {
             .descendant_verify_with_hash(&path, &digest.as_ref()[..], &hash_func, &sig)
             .unwrap();
 
-        let err_bad_sig =
-            key_pub.descendant_verify_with_hash(&path, &wrong_digest.as_ref()[..], &hash_func, &sig);
+        let err_bad_sig = key_pub.descendant_verify_with_hash(
+            &path,
+            &wrong_digest.as_ref()[..],
+            &hash_func,
+            &sig,
+        );
         match err_bad_sig {
             Err(Bip32Error::BackendError(_)) => {}
             _ => assert!(false, "expected signature validation error"),
@@ -551,7 +560,9 @@ mod test {
 
         // sign + verify
         let sig = key.descendant_sign(&path, &digest.as_ref()[..]).unwrap();
-        key_pub.descendant_verify(&path, &digest.as_ref()[..], &sig).unwrap();
+        key_pub
+            .descendant_verify(&path, &digest.as_ref()[..], &sig)
+            .unwrap();
 
         let err_bad_sig = key_pub.descendant_verify(&path, &wrong_digest.as_ref()[..], &sig);
         match err_bad_sig {
@@ -560,12 +571,15 @@ mod test {
         }
 
         // sign_recoverable + verify_recoverable
-        let sig = key.descendant_sign_recoverable(&path, &digest.as_ref()[..]).unwrap();
+        let sig = key
+            .descendant_sign_recoverable(&path, &digest.as_ref()[..])
+            .unwrap();
         key_pub
             .descendant_verify_recoverable(&path, &digest.as_ref()[..], &sig)
             .unwrap();
 
-        let err_bad_sig = key_pub.descendant_verify_recoverable(&path, &wrong_digest.as_ref()[..], &sig);
+        let err_bad_sig =
+            key_pub.descendant_verify_recoverable(&path, &wrong_digest.as_ref()[..], &sig);
         match err_bad_sig {
             Err(Bip32Error::BackendError(_)) => {}
             _ => assert!(false, "expected signature validation error"),

--- a/bip32/src/prelude.rs
+++ b/bip32/src/prelude.rs
@@ -1,4 +1,7 @@
 pub use crate::curve::model;
+pub use crate::model::*;
+
+pub use crate::curve::Secp256k1;
+
 #[cfg(any(feature = "mainnet", feature = "testnet"))]
 pub use crate::defaults::*;
-pub use crate::model::*;

--- a/bitcoins-wasm/Cargo.toml
+++ b/bitcoins-wasm/Cargo.toml
@@ -19,7 +19,7 @@ opt-level = 'z'
 [dependencies]
 coins-core = {path = "../core"}
 bitcoins = {path = "../bitcoins"}
-wasm-bindgen = "0.2.60"
+wasm-bindgen = "0.2.65"
 js-sys = "0.3.37"
 bitcoin-spv = "4.0.1"
 thiserror = "1.0"
@@ -28,3 +28,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.12"
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/bitcoins/src/builder.rs
+++ b/bitcoins/src/builder.rs
@@ -207,7 +207,8 @@ where
                 self.vout,
                 self.witnesses,
                 self.locktime,
-            )?.into())
+            )?
+            .into())
         } else {
             Ok(LegacyTx::new(self.version, self.vin, self.vout, self.locktime)?.into())
         }

--- a/bitcoins/src/enc/encoder.rs
+++ b/bitcoins/src/enc/encoder.rs
@@ -85,7 +85,10 @@ impl<P: NetworkParams> AddressEncoder for BitcoinEncoder<P> {
         match s.standard_type() {
             ScriptType::PKH(payload) => {
                 // s.items contains the op codes. we want only the pkh
-                Ok(Address::PKH(encode_base58(P::PKH_VERSION, payload.as_ref())))
+                Ok(Address::PKH(encode_base58(
+                    P::PKH_VERSION,
+                    payload.as_ref(),
+                )))
             }
             ScriptType::SH(payload) => {
                 // s.items contains the op codes. we want only the sh

--- a/bitcoins/src/hashes.rs
+++ b/bitcoins/src/hashes.rs
@@ -3,20 +3,24 @@
 
 use bitcoin_spv::types::Hash256Digest;
 
-use coins_core::hashes::marked::MarkedDigest;
+use coins_core::{hashes::marked::MarkedDigest, mark_32_byte_hash};
 
-mark_hash256!(
+coins_core::mark_32_byte_hash!(
     /// A marked Hash256Digest representing transaction IDs
-    TXID
-);
-mark_hash256!(
-    /// A marked Hash256Digest representing witness transaction IDs
-    WTXID
+    TXID,
+    Hash256Digest
 );
 
-mark_hash256!(
+mark_32_byte_hash!(
+    /// A marked Hash256Digest representing witness transaction IDs
+    WTXID,
+    Hash256Digest
+);
+
+mark_32_byte_hash!(
     /// A marked Hash256Digest representing a block hash
-    BlockHash
+    BlockHash,
+    Hash256Digest
 );
 
 #[cfg(test)]

--- a/bitcoins/src/lib.rs
+++ b/bitcoins/src/lib.rs
@@ -5,11 +5,6 @@
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 
-#[macro_use]
-#[doc(hidden)]
-#[cfg_attr(tarpaulin, skip)]
-pub mod macros;
-
 pub mod builder;
 pub mod enc;
 pub mod hashes;

--- a/bitcoins/src/types/legacy.rs
+++ b/bitcoins/src/types/legacy.rs
@@ -157,11 +157,11 @@ impl Transaction for LegacyTx {
         let vouts = vout.into();
 
         if vins.is_empty() {
-            return Err(TxError::EmptyVin)
+            return Err(TxError::EmptyVin);
         }
 
         if vouts.is_empty() {
-            return Err(TxError::EmptyVout)
+            return Err(TxError::EmptyVout);
         }
 
         Ok(Self {

--- a/bitcoins/src/types/script.rs
+++ b/bitcoins/src/types/script.rs
@@ -21,7 +21,10 @@
 //! let script = bitcoins::types::Script::from(script.into_bytes());
 //! ```
 use bitcoin_spv::types::{Hash160Digest, Hash256Digest};
-use coins_core::types::tx::RecipientIdentifier;
+use coins_core::{
+    impl_hex_serde, impl_script_conversion, types::tx::RecipientIdentifier,
+    wrap_prefixed_byte_vector,
+};
 
 /// A wrapped script.
 pub trait BitcoinScript {}

--- a/bitcoins/src/types/witness.rs
+++ b/bitcoins/src/types/witness.rs
@@ -38,7 +38,13 @@ pub trait WitnessTransaction: BitcoinTransaction {
     type Witness;
 
     /// Instantiate a new WitnessTx from the arguments.
-    fn new<I, O, W>(version: u32, vin: I, vout: O, witnesses: W, locktime: u32) -> Result<Self, Self::TxError>
+    fn new<I, O, W>(
+        version: u32,
+        vin: I,
+        vout: O,
+        witnesses: W,
+        locktime: u32,
+    ) -> Result<Self, Self::TxError>
     where
         I: Into<Vec<Self::TxIn>>,
         O: Into<Vec<Self::TxOut>>,
@@ -295,7 +301,13 @@ impl WitnessTransaction for WitnessTx {
     /// ensure that there are the same number of witnesses as inputs.
     /// The number of witnesses will be trimmed if there are too many
     /// and will be filled with empty witnesses if too few.
-    fn new<I, O, W>(version: u32, vin: I, vout: O, witnesses: W, locktime: u32) -> Result<Self, Self::TxError>
+    fn new<I, O, W>(
+        version: u32,
+        vin: I,
+        vout: O,
+        witnesses: W,
+        locktime: u32,
+    ) -> Result<Self, Self::TxError>
     where
         I: Into<Vec<Self::TxIn>>,
         O: Into<Vec<Self::TxOut>>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,9 @@
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 
+#[cfg_attr(tarpaulin, skip)]
+pub mod macros;
+
 pub mod builder;
 pub mod enc;
 pub mod hashes;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -374,7 +374,6 @@ impl ByteFormat for bitcoin_spv::types::RawHeader {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/ledger-btc/Cargo.toml
+++ b/ledger-btc/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 [dev-dependencies]
 futures = "0.3.5"
 serial_test = "0.3.2"
+tokio = {version = "0.2.22", features = ["rt-threaded", "macros"]}
 
 [dependencies]
 thiserror = "1.0.10"
@@ -43,3 +44,7 @@ default = ["native"]
 native = []
 browser = ["coins-ledger/browser"]
 node = ["coins-ledger/node"]
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -49,3 +49,7 @@ tokio = {version = "0.2.22", features = ["rt-threaded", "macros"]}
 [features]
 browser = []
 node = []
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/ledger/node_tests/package-lock.json
+++ b/ledger/node_tests/package-lock.json
@@ -692,6 +692,9 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@summa-tx/coins-ledger": {
+      "version": "file:coins_ledger"
+    },
     "@summa-tx/rmn-ledger": {
       "version": "file:rmn_ledger",
       "dependencies": {

--- a/ledger/node_tests/package.json
+++ b/ledger/node_tests/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@ledgerhq/hw-transport-node-hid": "^5.15.0",
-    "@summa-tx/rmn-ledger": "file:rmn_ledger"
+    "@summa-tx/coins-ledger": "file:coins_ledger",
   },
   "devDependencies": {
     "jest": "^26.0.1"

--- a/litecoins/Cargo.toml
+++ b/litecoins/Cargo.toml
@@ -11,3 +11,7 @@ repository = "https://github.com/summa-tx/bitcoins-rs"
 [dependencies]
 bitcoins = {path = "../bitcoins"}
 coins-core = { path = "../core"}
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -46,3 +46,7 @@ fetch = ["reqwest", "hex", "serde", "serde_json", "bytes"]
 # mutually exclusive
 mainnet = ["bitcoins/mainnet"]
 testnet = ["bitcoins/testnet"]
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/provider/src/utils.rs
+++ b/provider/src/utils.rs
@@ -97,7 +97,8 @@ pub fn create_tree(leaves: &[TXID]) -> Vec<TXID> {
                 let right = nodes[i + k];
 
                 let mut ctx = Hash256Writer::default();
-                ctx.write_all(left.0.as_ref()).expect("no error on heap allocation");
+                ctx.write_all(left.0.as_ref())
+                    .expect("no error on heap allocation");
                 ctx.write_all(right.0.as_ref())
                     .expect("no error on heap allocation");
                 let digest = ctx.finish();

--- a/psbt/Cargo.toml
+++ b/psbt/Cargo.toml
@@ -32,3 +32,7 @@ node = ["ledger", "bitcoins-ledger/node"]
 ledger = ["futures", "bitcoins-ledger"]
 mainnet = ["bitcoins/mainnet", "coins-bip32/mainnet"]
 testnet = ["bitcoins/testnet", "coins-bip32/testnet"]
+
+# https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]

--- a/psbt/src/common.rs
+++ b/psbt/src/common.rs
@@ -2,13 +2,9 @@ use std::{collections::btree_map, io::Error as IOError, ops::RangeBounds};
 
 use thiserror::Error;
 
-use coins_core::ser::SerError;
+use coins_core::{impl_hex_serde, ser::SerError, wrap_prefixed_byte_vector};
 
-use bitcoins::{
-    impl_hex_serde,
-    types::{ScriptType, TxError},
-    wrap_prefixed_byte_vector,
-};
+use bitcoins::types::{ScriptType, TxError};
 
 use crate::schema;
 

--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -652,6 +652,11 @@ mod test {
     #[test]
     fn it_decodes_a_thing() {
         let b64 = "cHNidP8BAHECAAAAAeBANSdI+VT5VJvVfchN4UEUniZ5cfeucBkBuoA475wjAAAAAAD+////AgDh9QUAAAAAFgAU7gEhvO/VGbeMDvk2DeqaTVkRQh8AERAkAQAAABYAFCQ8xyUkB4v4DqmV7T6aVADqs8M5AAAAAAABAR8A8gUqAQAAABYAFO4BIbzv1Rm3jA75Ng3qmk1ZEUIfIgYDbXrhM7lpiaTJhxwJSplsX1r33gCcoD9xL4wEteLypE8YRwNsJ1QAAIABAACAAAAAgAAAAAAAAAAAACICA2164TO5aYmkyYccCUqZbF9a994AnKA/cS+MBLXi8qRPGEcDbCdUAACAAQAAgAAAAIAAAAAAAAAAAAAiAgONam8JJOdoEr/jubocGRelQAnn2NfLVM7jLliPK0n8KBhHA2wnVAAAgAEAAIAAAACAAQAAAAAAAAAA".to_owned();
-        assert_eq!(b64, MainnetPSBT::deserialize_base64(&b64).unwrap().serialize_base64());
+        assert_eq!(
+            b64,
+            MainnetPSBT::deserialize_base64(&b64)
+                .unwrap()
+                .serialize_base64()
+        );
     }
 }

--- a/psbt/src/roles/bip32_signer.rs
+++ b/psbt/src/roles/bip32_signer.rs
@@ -78,7 +78,10 @@ impl Bip32Signer {
             _ => {
                 return Err(PSBTError::WrongPrevoutScriptType {
                     got: prevout.script_pubkey.standard_type(),
-                    expected: vec![ScriptType::WSH(Hash256Digest::default()), ScriptType::WPKH(Hash160Digest::default())],
+                    expected: vec![
+                        ScriptType::WSH(Hash256Digest::default()),
+                        ScriptType::WPKH(Hash160Digest::default()),
+                    ],
                 })
             }
         }


### PR DESCRIPTION
- Moves useful macros from `bitcoins` to `coins_core`.
- Fix bip32 benches using old API
- Temporary fix for wasm-pack issue (https://github.com/rustwasm/wasm-pack/issues/886)
- `cargo fmt`