### PR TITLE
feature: operation modes for read_seq_from

### DIFF
--- a/bitcoins/src/enc/encoder.rs
+++ b/bitcoins/src/enc/encoder.rs
@@ -93,7 +93,10 @@ impl<P: NetworkParams> AddressEncoder for BitcoinEncoder<P> {
             }
             ScriptType::SH(payload) => {
                 // s.items contains the op codes. we want only the sh
-                Ok(Address::SH(encode_base58(P::SH_VERSION, payload.as_slice())))
+                Ok(Address::SH(encode_base58(
+                    P::SH_VERSION,
+                    payload.as_slice(),
+                )))
             }
             ScriptType::WSH(_) => Ok(Address::WSH(encode_bech32(P::HRP, &s.items())?)),
             ScriptType::WPKH(_) => Ok(Address::WPKH(encode_bech32(P::HRP, &s.items())?)),

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,4 +1,9 @@
 //! Re-exports of common traits.
 pub use crate::{
-    builder::TxBuilder, enc::*, hashes::*, nets::Network, ser::{ByteFormat, ReadSequenceMode}, types::Transaction,
+    builder::TxBuilder,
+    enc::*,
+    hashes::*,
+    nets::Network,
+    ser::{ByteFormat, ReadSequenceMode},
+    types::Transaction,
 };

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -4,6 +4,6 @@ pub use crate::{
     enc::*,
     hashes::*,
     nets::Network,
-    ser::{ByteFormat, ReadSequenceMode},
+    ser::{ByteFormat, ReadSeqMode},
     types::Transaction,
 };

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,4 +1,4 @@
 //! Re-exports of common traits.
 pub use crate::{
-    builder::TxBuilder, enc::*, hashes::*, nets::Network, ser::ByteFormat, types::Transaction,
+    builder::TxBuilder, enc::*, hashes::*, nets::Network, ser::{ByteFormat, ReadSequenceMode}, types::Transaction,
 };

--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -365,9 +365,11 @@ where
                 return Err(PSBTError::ScriptSigInTx);
             }
         }
-        let inputs = PSBTInput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.inputs().len()))?;
+        let inputs =
+            PSBTInput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.inputs().len()))?;
 
-        let outputs = PSBTOutput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.outputs().len()))?;
+        let outputs =
+            PSBTOutput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.outputs().len()))?;
 
         let result = PSBT {
             global,

--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -365,11 +365,9 @@ where
                 return Err(PSBTError::ScriptSigInTx);
             }
         }
-        let inputs =
-            PSBTInput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.inputs().len()))?;
+        let inputs = PSBTInput::read_seq_from(reader, ReadSeqMode::Exactly(tx.inputs().len()))?;
 
-        let outputs =
-            PSBTOutput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.outputs().len()))?;
+        let outputs = PSBTOutput::read_seq_from(reader, ReadSeqMode::Exactly(tx.outputs().len()))?;
 
         let result = PSBT {
             global,

--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -365,9 +365,9 @@ where
                 return Err(PSBTError::ScriptSigInTx);
             }
         }
-        let inputs = PSBTInput::read_seq_from(reader, tx.inputs().len())?;
+        let inputs = PSBTInput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.inputs().len()))?;
 
-        let outputs = PSBTOutput::read_seq_from(reader, tx.outputs().len())?;
+        let outputs = PSBTOutput::read_seq_from(reader, ReadSequenceMode::Exactly(tx.outputs().len()))?;
 
         let result = PSBT {
             global,

--- a/psbt/src/schema.rs
+++ b/psbt/src/schema.rs
@@ -187,7 +187,10 @@ pub fn try_val_as_signature(val: &PSBTValue) -> Result<(Signature, Sighash), PSB
 pub fn try_val_as_witness(val: &PSBTValue) -> Result<Witness, PSBTError> {
     let mut wit_bytes = &val.items()[..];
     let number = ser::read_compact_int(&mut wit_bytes)? as usize;
-    Ok(WitnessStackItem::read_seq_from(&mut wit_bytes, ReadSequenceMode::Exactly(number))?)
+    Ok(WitnessStackItem::read_seq_from(
+        &mut wit_bytes,
+        ReadSequenceMode::Exactly(number),
+    )?)
 }
 
 /// Attempt to parse a key as a valid extended pubkey

--- a/psbt/src/schema.rs
+++ b/psbt/src/schema.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use coins_core::ser::{self, ByteFormat, ReadSequenceMode};
+use coins_core::ser::{self, ByteFormat, ReadSeqMode};
 
 use coins_bip32::{
     self as bip32,
@@ -189,7 +189,7 @@ pub fn try_val_as_witness(val: &PSBTValue) -> Result<Witness, PSBTError> {
     let number = ser::read_compact_int(&mut wit_bytes)? as usize;
     Ok(WitnessStackItem::read_seq_from(
         &mut wit_bytes,
-        ReadSequenceMode::Exactly(number),
+        ReadSeqMode::Exactly(number),
     )?)
 }
 

--- a/psbt/src/schema.rs
+++ b/psbt/src/schema.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use coins_core::ser::{self, ByteFormat};
+use coins_core::ser::{self, ByteFormat, ReadSequenceMode};
 
 use coins_bip32::{
     self as bip32,
@@ -187,7 +187,7 @@ pub fn try_val_as_signature(val: &PSBTValue) -> Result<(Signature, Sighash), PSB
 pub fn try_val_as_witness(val: &PSBTValue) -> Result<Witness, PSBTError> {
     let mut wit_bytes = &val.items()[..];
     let number = ser::read_compact_int(&mut wit_bytes)? as usize;
-    Ok(WitnessStackItem::read_seq_from(&mut wit_bytes, number)?)
+    Ok(WitnessStackItem::read_seq_from(&mut wit_bytes, ReadSequenceMode::Exactly(number))?)
 }
 
 /// Attempt to parse a key as a valid extended pubkey


### PR DESCRIPTION
Allows the caller to choose between 3 modes for `read_seq_from`

TODO
- [x] quick tests