### PR TITLE
Update RustCryptoTraits and workspace deps use internal paths.

### DIFF
--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coins-bip32"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["James Prestwich <james@prestwi.ch>"]
 edition = "2018"
 description = "Bip32 (and related BIPs) in Rust"
@@ -9,14 +9,16 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 thiserror = "1.0"
-hmac = "0.7.1"
-sha2 = "0.8.0"
-bs58 = "0.3.0"
+hmac = "0.11.0"
+sha2 = "0.9.5"
+bs58 = "0.4.0"
 lazy_static = "1.4.0"
 coins-core = "0.2.0"
 serde = "1.0.105"
+bincode = "1.3.3"
 
-k256 = { version = "0.7.1", features = ["std", "ecdsa", "arithmetic"] }
+k256 = { version = "0.9.4", features = ["std", "arithmetic"] }
+digest = "0.9.0"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/bip32/src/derived.rs
+++ b/bip32/src/derived.rs
@@ -544,11 +544,11 @@ mod test {
             88, 150, 169, 207, 206, 194, 195, 181, 114, 208, 131, 113, 168, 68, 23, 157, 22, 133,
             212, 235, 131, 6, 145, 26, 162, 81, 0,
         ];
-        assert_eq!(Signature::from(sig.clone()).to_asn1().as_bytes(), der_sig);
+        assert_eq!(Signature::from(sig.clone()).to_der().as_bytes(), der_sig);
         assert_eq!(sig.as_ref(), rsv);
         assert_eq!(
             Signature::from(sig),
-            Signature::from_asn1(&der_sig).unwrap(),
+            Signature::from_der(&der_sig).unwrap(),
         );
         assert_eq!(sig, RecoverableSignature::from_bytes(&rsv).unwrap());
     }

--- a/bip32/src/macros.rs
+++ b/bip32/src/macros.rs
@@ -2,13 +2,13 @@ macro_rules! inherit_signer {
     ($struct_name:ident.$attr:ident) => {
         impl<D> k256::ecdsa::signature::DigestSigner<D, k256::ecdsa::Signature> for $struct_name
         where
-            D: k256::elliptic_curve::digest::BlockInput
-                + k256::elliptic_curve::digest::FixedOutput<
+            D: digest::BlockInput
+                + digest::FixedOutput<
                     OutputSize = k256::elliptic_curve::consts::U32,
                 > + Clone
                 + Default
-                + k256::elliptic_curve::digest::Reset
-                + k256::elliptic_curve::digest::Update,
+                + digest::Reset
+                + digest::Update,
         {
             fn try_sign_digest(
                 &self,
@@ -21,13 +21,13 @@ macro_rules! inherit_signer {
         impl<D> k256::ecdsa::signature::DigestSigner<D, k256::ecdsa::recoverable::Signature>
             for $struct_name
         where
-            D: k256::elliptic_curve::digest::BlockInput
-                + k256::elliptic_curve::digest::FixedOutput<
+            D: digest::BlockInput
+                + digest::FixedOutput<
                     OutputSize = k256::elliptic_curve::consts::U32,
                 > + Clone
                 + Default
-                + k256::elliptic_curve::digest::Reset
-                + k256::elliptic_curve::digest::Update,
+                + digest::Reset
+                + digest::Update,
         {
             fn try_sign_digest(
                 &self,
@@ -44,13 +44,17 @@ macro_rules! inherit_verifier {
         impl $struct_name {
             /// Get the sec1 representation of the public key
             pub fn to_bytes(&self) -> [u8; 33] {
-                self.$attr.to_bytes()
+                let mut data = [0u8; 33];
+                let generic_array = self.$attr.to_bytes();
+                data.copy_from_slice(&generic_array);
+                data
+
             }
         }
 
         impl<D> k256::ecdsa::signature::DigestVerifier<D, k256::ecdsa::Signature> for $struct_name
         where
-            D: k256::elliptic_curve::digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>,
+            D: digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>,
         {
             fn verify_digest(
                 &self,
@@ -64,7 +68,7 @@ macro_rules! inherit_verifier {
         impl<D> k256::ecdsa::signature::DigestVerifier<D, k256::ecdsa::recoverable::Signature>
             for $struct_name
         where
-            D: k256::elliptic_curve::digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>,
+            D: digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>,
         {
             fn verify_digest(
                 &self,

--- a/bip32/src/xkeys.rs
+++ b/bip32/src/xkeys.rs
@@ -23,9 +23,9 @@ fn hmac_and_split(
     seed: &[u8],
     data: &[u8],
 ) -> Result<(k256::NonZeroScalar, ChainCode), Bip32Error> {
-    let mut mac = Hmac::<Sha512>::new_varkey(seed).expect("key length is ok");
-    mac.input(data);
-    let result = mac.result().code();
+    let mut mac:Hmac::<Sha512> = hmac::NewMac::new_from_slice(seed).expect("key length is ok");
+    mac.update(data);
+    let result = mac.finalize().into_bytes();
 
     let left = k256::NonZeroScalar::try_from(&result[..32])?;
 
@@ -122,7 +122,7 @@ impl XPriv {
     /// Derive the associated XPub
     pub fn verify_key(&self) -> XPub {
         XPub {
-            key: self.key.verify_key(),
+            key: self.key.verifying_key(),
             xkey_info: self.xkey_info,
         }
     }
@@ -224,7 +224,7 @@ impl Parent for XPriv {
             data.extend(&key.to_bytes());
             data.extend(&index.to_be_bytes());
         } else {
-            data.extend(&key.verify_key().to_bytes());
+            data.extend(&key.verifying_key().to_bytes());
             data.extend(&index.to_be_bytes());
         };
 

--- a/bip39/Cargo.toml
+++ b/bip39/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coins-bip39"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Rohit Narurkar <rohit.narurkar@protonmail.com>"]
 edition = "2018"
 description = "Bip39 in Rust"
@@ -9,10 +9,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitvec = "0.17.4"
-coins-bip32 = "0.2.0"
+coins-bip32 = {version ="0.3.0",path = "../bip32"}
 hex = "0.4.2"
-hmac = "0.10.1"
-pbkdf2 = "0.7.3"
-rand = "0.7.0"
+hmac = "0.11.0"
+pbkdf2 = "0.8.0"
+rand = "0.8.4"
 sha2 = "0.9.3"
 thiserror = "1.0"

--- a/bip39/Cargo.toml
+++ b/bip39/Cargo.toml
@@ -16,3 +16,8 @@ pbkdf2 = "0.8.0"
 rand = "0.8.4"
 sha2 = "0.9.3"
 thiserror = "1.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2.3"
+default-features = false
+features=["js"]

--- a/bitcoins/Cargo.toml
+++ b/bitcoins/Cargo.toml
@@ -14,7 +14,7 @@ base58check = "0.1.0"
 thiserror = "1.0"
 serde = "1.0.105"
 
-coins-core = {version ="0.2.2", path = "../core"}
+coins-core = {version ="0.3.0", path = "../core"}
 coins-bip32 = { version = "0.3.0", path = "../bip32", default-features =  false }
 
 [features]

--- a/bitcoins/Cargo.toml
+++ b/bitcoins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoins"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["James Prestwich <james@prestwi.ch>"]
 edition = "2018"
 description = "Bitcoin transaction construction in Rust"
@@ -14,8 +14,8 @@ base58check = "0.1.0"
 thiserror = "1.0"
 serde = "1.0.105"
 
-coins-core = "0.2.0"
-coins-bip32 = { version = "0.2.0", default-features =  false }
+coins-core = {version ="0.2.2", path = "../core"}
+coins-bip32 = { version = "0.3.0", path = "../bip32", default-features =  false }
 
 [features]
 default = ["mainnet"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coins-core"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["James Prestwich <james@prestwi.ch>"]
 edition = "2018"
 description = "Abstract UTXO transactions to enable code reuse across chains"

--- a/handshakes/Cargo.toml
+++ b/handshakes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handshakes"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Mark Tyneway <mark.tyneway@gmail.com>"]
 edition = "2018"
 description = "Handshake transaction construction in Rust"
@@ -18,5 +18,5 @@ serde = "1.0.105"
 
 
 coins-core = "0.2.0"
-coins-bip32 = { version = "0.2.0", default-features =  false }
-bitcoins =  "0.2.0"
+coins-bip32 = { version = "0.3.0", path ="../bip32",default-features =  false }
+bitcoins =  {version = "0.3.0", path="../bitcoins"}

--- a/handshakes/Cargo.toml
+++ b/handshakes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handshakes"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Mark Tyneway <mark.tyneway@gmail.com>"]
 edition = "2018"
 description = "Handshake transaction construction in Rust"
@@ -17,6 +17,6 @@ sha3 = "0.8.2"
 serde = "1.0.105"
 
 
-coins-core = "0.2.0"
+coins-core = {version = "0.3.0", path = "../core"}
 coins-bip32 = { version = "0.3.0", path ="../bip32",default-features =  false }
 bitcoins =  {version = "0.3.0", path="../bitcoins"}

--- a/ledger-btc/Cargo.toml
+++ b/ledger-btc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoins-ledger"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["James Prestwich <james@prestwi.ch>"]
 edition = "2018"
 categories  = ["authentication", "cryptography"]
@@ -20,7 +20,7 @@ tokio = {version = "0.2.22", features = ["rt-threaded", "macros"]}
 [dependencies]
 thiserror = "1.0.10"
 futures = "0.3.5"
-coins-core = "0.2.0"
+coins-core = {version = "0.3.0", path = "../core"}
 coins-bip32 = { version = "0.3.0", path = "../bip32",default-features =  false }
 bitcoins = { version = "0.3.0",path = "../bitcoins", default-features =  false }
 coins-ledger = { version = "0.2.0", default-features =  false }

--- a/ledger-btc/Cargo.toml
+++ b/ledger-btc/Cargo.toml
@@ -21,8 +21,8 @@ tokio = {version = "0.2.22", features = ["rt-threaded", "macros"]}
 thiserror = "1.0.10"
 futures = "0.3.5"
 coins-core = "0.2.0"
-coins-bip32 = { version = "0.2.0", default-features =  false }
-bitcoins = { version = "0.2.0", default-features =  false }
+coins-bip32 = { version = "0.3.0", path = "../bip32",default-features =  false }
+bitcoins = { version = "0.3.0",path = "../bitcoins", default-features =  false }
 coins-ledger = { version = "0.2.0", default-features =  false }
 
 

--- a/ledger-btc/src/app.rs
+++ b/ledger-btc/src/app.rs
@@ -1,7 +1,6 @@
 use crate::{utils::*, LedgerBTCError};
-use bitcoins::types::{BitcoinTxIn, Utxo, WitnessTx};
+use bitcoins::{prelude::Transaction, types::{BitcoinTxIn, Utxo, WitnessTx}};
 use coins_bip32::{path::DerivationPath, prelude::*};
-use coins_core::Transaction;
 use coins_ledger::{
     common::{APDUAnswer, APDUCommand},
     transports::{Ledger, LedgerAsync},

--- a/ledger-btc/src/utils.rs
+++ b/ledger-btc/src/utils.rs
@@ -1,6 +1,6 @@
-use bitcoins::types::{BitcoinTxIn, ScriptType, SpendScript, TxOut, Utxo};
+use bitcoins::{prelude::ByteFormat, types::{BitcoinTxIn, ScriptType, SpendScript, TxOut, Utxo}};
 use coins_bip32::{path::DerivationPath, prelude::*};
-use coins_core::ser::{self, ByteFormat};
+use coins_core::ser;
 use coins_ledger::common::{APDUAnswer, APDUCommand, APDUData};
 
 use crate::LedgerBTCError;
@@ -151,7 +151,7 @@ pub(crate) fn parse_sig(answer: &APDUAnswer) -> Result<Signature, LedgerBTCError
         .ok_or(LedgerBTCError::UnexpectedNullResponse)?
         .to_vec();
     sig[0] &= 0xfe;
-    Ok(Signature::from_asn1(&sig[..sig.len() - 1]).map_err(Bip32Error::from)?)
+    Ok(Signature::from_der(&sig[..sig.len() - 1]).map_err(Bip32Error::from)?)
 }
 
 pub(crate) fn should_sign(xpub: &DerivedXPub, signing_info: &[crate::app::SigningInfo]) -> bool {

--- a/ledger-btc/tests/integration.rs
+++ b/ledger-btc/tests/integration.rs
@@ -1,7 +1,6 @@
-use bitcoins::types::{BitcoinTxIn, Script, ScriptPubkey, SpendScript, Utxo, WitnessTx};
+use bitcoins::{prelude::ByteFormat, types::{BitcoinTxIn, Script, ScriptPubkey, SpendScript, Utxo, WitnessTx}};
 use bitcoins_ledger::*;
 use coins_bip32::{derived::DerivedKey, enc::XKeyEncoder, path::KeyDerivation};
-use coins_core::ser::ByteFormat;
 
 use serial_test::serial;
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coins-ledger"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Summa <team@summa.one>", "James Prestwich <james@summa.one>", "Zondax GmbH <info@zondax.ch>"]
 edition = "2018"
 categories  = ["authentication", "cryptography"]

--- a/litecoins/Cargo.toml
+++ b/litecoins/Cargo.toml
@@ -10,7 +10,7 @@ description = "Litecoin transaction construction in Rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoins = "0.2.0"
+bitcoins = {version = "0.3.0", path= "../bitcoins"}
 coins-core = "0.2.0"
 
 # https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802

--- a/litecoins/Cargo.toml
+++ b/litecoins/Cargo.toml
@@ -11,7 +11,7 @@ description = "Litecoin transaction construction in Rust"
 
 [dependencies]
 bitcoins = {version = "0.3.0", path= "../bitcoins"}
-coins-core = "0.2.0"
+coins-core = {version = "0.3.0", path = "../core"}
 
 # https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-667669802
 [package.metadata.wasm-pack.profile.release]

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoins-provider"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["James Prestwich <james@prestwi.ch>"]
 edition = "2018"
 repository = "https://github.com/summa-tx/bitcoins-rs"
@@ -18,7 +18,7 @@ pin-project = { version = "0.4.20", default-features = false }
 lru = { version = "0.5.2" }
 
 # other projects in this workspace
-coins-core = {version = "0.2.0", path = "../core"}
+coins-core = {version = "0.3.0", path = "../core"}
 bitcoins = {version = "0.3.0", path= "../bitcoins"}
 
 # RPC only

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -18,8 +18,8 @@ pin-project = { version = "0.4.20", default-features = false }
 lru = { version = "0.5.2" }
 
 # other projects in this workspace
-coins-core = "0.2.0"
-bitcoins = { version = "0.2.0", default-features = false }
+coins-core = {version = "0.2.0", path = "../core"}
+bitcoins = {version = "0.3.0", path= "../bitcoins"}
 
 # RPC only
 secrecy = { version = "0.7.0", optional = true }

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -36,6 +36,11 @@ bytes = { version = "^0.5", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2.62", features = ["serde-serialize"]  }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2.3"
+default-features = false
+features=["js"]
+
 [dev-dependencies]
 tokio = "0.2.21"
 


### PR DESCRIPTION
- Update crypto traits in bip32
- Make dependencies within the workspace start to use internal paths