### PR TITLE
replace hidapi for hidapi-rusb

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -29,10 +29,8 @@ cfg-if = "0.1.7"
 matches = "0.1.8"
 
 # native
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.hidapi]
-version = "1.1.1"
-default-features = false
-features=["linux-static-hidraw"]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.hidapi-rusb]
+version = "1.3.0"
 
 # linux native only
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/ledger/README.md
+++ b/ledger/README.md
@@ -8,8 +8,6 @@ Windows is not yet supported.
 
 ### Native
 - Install dependencies
-  - Linux
-    - `$ sudo apt-get install libudev-dev libusb-1.0-0-dev`
   - OSX
     - TODO
     - please file an issue if you know. I don't have a macbook :)

--- a/ledger/src/transports/hid.rs
+++ b/ledger/src/transports/hid.rs
@@ -33,6 +33,8 @@ cfg_if! {
 }
 
 const LEDGER_VID: u16 = 0x2c97;
+
+#[cfg(not(target_os = "linux"))]
 const LEDGER_USAGE_PAGE: u16 = 0xFFA0;
 const LEDGER_CHANNEL: u16 = 0x0101;
 const LEDGER_PACKET_SIZE: u8 = 64;
@@ -126,10 +128,7 @@ impl TransportNativeHID {
     fn find_ledger_device_path(api: &hidapi_rusb::HidApi) -> Result<CString, NativeTransportError> {
         for device in api.device_list() {
             if device.vendor_id() == LEDGER_VID {
-                let usage_page = get_usage_page(&device.path())?;
-                if usage_page == LEDGER_USAGE_PAGE {
-                    return Ok(device.path().into());
-                }
+                return Ok(device.path().into());
             }
         }
         Err(NativeTransportError::DeviceNotFound)
@@ -313,6 +312,7 @@ if #[cfg(target_os = "linux")] {
         value: [u8; HID_MAX_DESCRIPTOR_SIZE],
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn get_usage_page(device_path: &CStr) -> Result<u16, NativeTransportError>
     {
         // #define HIDIOCGRDESCSIZE	_IOR('H', 0x01, int)


### PR DESCRIPTION
Replaces [hidapi](https://crates.io/crates/hidapi) for [hidapi-rusb](https://crates.io/crates/hidapi-rusb). 

It's a minimal fork, where the only difference is that `hidapi-rusb` takes by default the `libusb` backend built by `rusb.` (feature: `libusb-static-rusb`). This way, it no longer depends on `libudev-dev` or `libusb-1.0-0-dev`.