### PR TITLE
chore: upgrade asymmetric crytpo dependencies

### DIFF
--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -17,8 +17,8 @@ coins-core = "0.2.0"
 serde = "1.0.105"
 bincode = "1.3.3"
 
-k256 = { version = "0.10", features = ["std", "arithmetic"] }
-digest = "0.9.0"
+k256 = { version = "0.11", features = ["std", "arithmetic"] }
+digest = "0.10.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/bip32/src/macros.rs
+++ b/bip32/src/macros.rs
@@ -2,13 +2,14 @@ macro_rules! inherit_signer {
     ($struct_name:ident.$attr:ident) => {
         impl<D> k256::ecdsa::signature::DigestSigner<D, k256::ecdsa::Signature> for $struct_name
         where
-            D: digest::BlockInput
-                + digest::FixedOutput<
-                    OutputSize = k256::elliptic_curve::consts::U32,
-                > + Clone
+            D: digest::FixedOutput<OutputSize = k256::elliptic_curve::consts::U32>
+                + Clone
                 + Default
                 + digest::Reset
-                + digest::Update,
+                + digest::Update
+                + k256::ecdsa::digest::FixedOutput
+                + k256::ecdsa::digest::HashMarker
+                + std::default::Default,
         {
             fn try_sign_digest(
                 &self,
@@ -21,13 +22,14 @@ macro_rules! inherit_signer {
         impl<D> k256::ecdsa::signature::DigestSigner<D, k256::ecdsa::recoverable::Signature>
             for $struct_name
         where
-            D: digest::BlockInput
-                + digest::FixedOutput<
-                    OutputSize = k256::elliptic_curve::consts::U32,
-                > + Clone
+            D: digest::FixedOutput<OutputSize = k256::elliptic_curve::consts::U32>
+                + Clone
                 + Default
                 + digest::Reset
-                + digest::Update,
+                + digest::Update
+                + k256::ecdsa::digest::FixedOutput
+                + k256::ecdsa::digest::HashMarker
+                + std::default::Default,
         {
             fn try_sign_digest(
                 &self,
@@ -48,13 +50,15 @@ macro_rules! inherit_verifier {
                 let generic_array = self.$attr.to_bytes();
                 data.copy_from_slice(&generic_array);
                 data
-
             }
         }
 
         impl<D> k256::ecdsa::signature::DigestVerifier<D, k256::ecdsa::Signature> for $struct_name
         where
-            D: digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>,
+            D: digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>
+                + k256::ecdsa::digest::FixedOutput
+                + k256::ecdsa::digest::HashMarker
+                + std::default::Default,
         {
             fn verify_digest(
                 &self,
@@ -68,7 +72,10 @@ macro_rules! inherit_verifier {
         impl<D> k256::ecdsa::signature::DigestVerifier<D, k256::ecdsa::recoverable::Signature>
             for $struct_name
         where
-            D: digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>,
+            D: digest::Digest<OutputSize = k256::elliptic_curve::consts::U32>
+                + k256::ecdsa::digest::FixedOutput
+                + k256::ecdsa::digest::HashMarker
+                + std::default::Default,
         {
             fn verify_digest(
                 &self,


### PR DESCRIPTION
Tries to upgrade asymmetric crypto dependencies of `coins-bip32` as described in #96.

The build currently errors with:

```
error[E0277]: the trait bound `k256::ecdsa::SigningKey: DigestSigner<D, _>` is not satisfied
  --> bip32/src/macros.rs:18:28
   |
18 |                 self.$attr.try_sign_digest(digest)
   |                            ^^^^^^^^^^^^^^^ the trait `DigestSigner<D, _>` is not implemented for `k256::ecdsa::SigningKey`
   |
  ::: bip32/src/xkeys.rs:87:1
   |
87 | inherit_signer!(XPriv.key);
   | -------------------------- in this macro invocation
   |
   = help: the following implementations were found:
             <k256::ecdsa::SigningKey as DigestSigner<D, ecdsa::Signature<Secp256k1>>>
             <k256::ecdsa::SigningKey as DigestSigner<D, k256::ecdsa::recoverable::Signature>>
   = note: this error originates in the macro `inherit_signer` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `k256::ecdsa::SigningKey: DigestSigner<D, _>` is not satisfied
  --> bip32/src/macros.rs:38:28
   |
38 |                 self.$attr.try_sign_digest(digest)
   |                            ^^^^^^^^^^^^^^^ the trait `DigestSigner<D, _>` is not implemented for `k256::ecdsa::SigningKey`
   |
  ::: bip32/src/xkeys.rs:87:1
   |
87 | inherit_signer!(XPriv.key);
   | -------------------------- in this macro invocation
   |
   = help: the following implementations were found:
             <k256::ecdsa::SigningKey as DigestSigner<D, ecdsa::Signature<Secp256k1>>>
             <k256::ecdsa::SigningKey as DigestSigner<D, k256::ecdsa::recoverable::Signature>>
   = note: this error originates in the macro `inherit_signer` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I've tried the following to no avail:

```rust
            fn verify_digest(
                &self,
                digest: D,
                signature: &k256::ecdsa::recoverable::Signature,
            ) -> Result<(), k256::ecdsa::Error> {
                use k256::ecdsa::signature::DigestSigner;
                self.$attr.verify_digest(digest, signature)
            }
```

and 

```rust
            fn verify_digest(
                &self,
                digest: D,
                signature: &k256::ecdsa::recoverable::Signature,
            ) -> Result<(), k256::ecdsa::Error> {
                k256::ecdsa::signature::DigestSigner::verify_digest(&self.$attr, digest, signature)
            }

```

