### PR TITLE
chore: bump hidapi-rusb

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -30,7 +30,7 @@ matches = "0.1.8"
 
 # native
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.hidapi-rusb]
-version = "1.3.1"
+version = "1.3.2"
 
 # linux native only
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
## Motivation
New version removes an unnecessary file modification on `build.rs`. This will also fix any build done by `docs.rs`, since it uses a read-only filesystem.

ref:
https://github.com/joshieDo/hidapi-rs/pull/5