### PR TITLE
Expose convenience

### DIFF
--- a/bip32/src/path.rs
+++ b/bip32/src/path.rs
@@ -20,7 +20,7 @@ fn try_parse_index(s: &str) -> Result<u32, Bip32Error> {
 
     index_str
         .parse::<u32>()
-        .map(|v| if harden { v + BIP32_HARDEN } else { v })
+        .map(|v| if harden { harden_index(v) } else { v })
         .map_err(|_| Bip32Error::MalformattedDerivation(s.to_owned()))
 }
 
@@ -39,6 +39,11 @@ fn encode_index(idx: u32, harden: char) -> String {
         s.push(harden);
     }
     s
+}
+
+/// Converts an raw index to hardened
+pub fn harden_index(index: u32) -> u32 {
+    index | (1 << 31)
 }
 
 /// A Bip32 derivation path

--- a/bip32/src/path.rs
+++ b/bip32/src/path.rs
@@ -44,7 +44,7 @@ fn encode_index(idx: u32, harden: char) -> String {
 
 /// Converts an raw index to hardened
 pub fn harden_index(index: u32) -> u32 {
-    index | (1 << 31)
+    index + BIP32_HARDEN
 }
 
 /// A Bip32 derivation path

--- a/bip32/src/path.rs
+++ b/bip32/src/path.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::TryFrom,
     io::{Read, Write},
     iter::{FromIterator, IntoIterator},
     slice::Iter,
@@ -169,6 +170,22 @@ impl From<&Vec<u32>> for DerivationPath {
 impl From<&[u32]> for DerivationPath {
     fn from(v: &[u32]) -> Self {
         Self(Vec::from(v))
+    }
+}
+
+impl TryFrom<u32> for DerivationPath {
+    type Error = Bip32Error;
+
+    fn try_from(v: u32) -> Result<Self, Self::Error> {
+        Ok(Self(vec![v]))
+    }
+}
+
+impl TryFrom<&str> for DerivationPath {
+    type Error = Bip32Error;
+
+    fn try_from(v: &str) -> Result<Self, Self::Error> {
+        try_parse_path(v).map(Into::into)
     }
 }
 

--- a/bip32/src/prelude.rs
+++ b/bip32/src/prelude.rs
@@ -9,10 +9,13 @@ pub use crate::Bip32Error;
 pub use crate::defaults::*;
 
 /// Re-exported signer traits
-pub use k256::ecdsa::{
-    recoverable::Signature as RecoverableSignature,
-    signature::{DigestSigner, DigestVerifier, Signature as SigTrait},
-    Signature, SigningKey, VerifyingKey,
+pub use k256::{
+    ecdsa::{
+        recoverable::Signature as RecoverableSignature,
+        signature::{DigestSigner, DigestVerifier, Signature as SigTrait},
+        Signature, SigningKey, VerifyingKey,
+    },
+    elliptic_curve::sec1::ToEncodedPoint,
 };
 
 /// shortcut for easy usage

--- a/bip32/src/prelude.rs
+++ b/bip32/src/prelude.rs
@@ -9,13 +9,14 @@ pub use crate::Bip32Error;
 pub use crate::defaults::*;
 
 /// Re-exported signer traits
+pub use k256;
 pub use k256::{
     ecdsa::{
         recoverable::Signature as RecoverableSignature,
-        signature::{DigestSigner, DigestVerifier, Signature as SigTrait},
+        signature::{DigestSigner as _, DigestVerifier as _, Signature as _},
         Signature, SigningKey, VerifyingKey,
     },
-    elliptic_curve::sec1::ToEncodedPoint,
+    elliptic_curve::sec1::ToEncodedPoint as _,
 };
 
 /// shortcut for easy usage

--- a/bip39/src/mnemonic.rs
+++ b/bip39/src/mnemonic.rs
@@ -431,4 +431,12 @@ mod tests {
                 );
             });
     }
+
+    #[test]
+    fn test_derive_key_try_into_derivation() {
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = Mnemonic::<W>::new_from_phrase(phrase).unwrap();
+        mnemonic.derive_key(0, None).unwrap();
+        mnemonic.derive_key("m/44'/61'/0'/0", None).unwrap();
+    }
 }

--- a/bip39/src/mnemonic.rs
+++ b/bip39/src/mnemonic.rs
@@ -170,7 +170,7 @@ impl<W: Wordlist> Mnemonic<W> {
         Ok(self.master_key(password)?.derive_path(path)?)
     }
 
-    fn to_seed(&self, password: Option<&str>) -> Result<Vec<u8>, MnemonicError> {
+    pub fn to_seed(&self, password: Option<&str>) -> Result<Vec<u8>, MnemonicError> {
         let mut seed = vec![0u8; PBKDF2_BYTES];
         let salt = format!("mnemonic{}", password.unwrap_or(""));
         pbkdf2::<Hmac<Sha512>>(


### PR DESCRIPTION
Included are commits for bip32 and bip39.  

- `bip32::path` added TryInto implementations for `DerivationPath` (u32 and &str).  This allows the `TryInto<DerivationPath>` parameter in `bip39::Mnemonic.derive_key` to be more ergonomic.

- `bip32::prelude` exports `ToEncodedPoint` for convenient access to `VerifyingKey.to_encoded_point`.  Many non-bitcoin chains use bip32 to derive wallets but use non-compressed public keys to generate the addresses.  This change makes it so those library consumers do not need to track k256 versions.

- `bip32::path` added function `hard_index` as a helper in case XPriv/XPub users manually call `Parent.derive_child`.  This allows the following usage: ```xpriv.derive_child(harden_index(0))```

- `bip39::Mnemonic.to_seed` has been changed to a public function so library users can manually call `XPriv::root_from_seed`.  This allows library users to decide what the final bitcoin address encoding is based on the `Hint`.  Otherwise, bip39 generated keys will always default to SegWit Hint.

Both unit tests run and passed.  New test added for `bip39::Mnemonic.derive_key`.