### PR TITLE
Fix Tarpaulin attribute

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,7 +17,7 @@
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[macro_use]
 pub mod macros;
 


### PR DESCRIPTION
Tarpaulin doesn't support `#[cfg_attr(tarpaulin, skip)]` anymore so running Tarpaulin required the `--avoid-cfg-tarpaulin` flag as described here: https://github.com/xd009642/tarpaulin#ignoring-code-in-files