### PR TITLE
chore: upgrade `k256` to 0.13

### DIFF
--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -17,7 +17,7 @@ coins-core = { version = "0.8.0", path = "../core" }
 serde = "1.0.105"
 bincode = "1.3.3"
 
-k256 = { version = "0.11", features = ["std", "arithmetic"] }
+k256 = { version = "0.13", features = ["std", "arithmetic"] }
 digest = "0.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/bip32/src/enc.rs
+++ b/bip32/src/enc.rs
@@ -174,7 +174,7 @@ pub trait XKeyEncoder {
 
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
-        let key = ecdsa::SigningKey::from_bytes(&buf)?;
+        let key = ecdsa::SigningKey::from_bytes(&buf.into())?;
 
         Ok(XPriv {
             key,
@@ -339,7 +339,7 @@ impl<P: NetworkParams> XKeyEncoder for BitcoinEncoder<P> {
         };
         let mut written = writer.write(&version.to_be_bytes())?;
         written += Self::write_key_details(writer, key.as_ref())?;
-        written += writer.write(key.as_ref().key.to_bytes().as_ref())?;
+        written += writer.write(key.as_ref().key.to_sec1_bytes().as_ref())?;
         Ok(written)
     }
 

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -28,11 +28,11 @@
 //! let xpriv: XPriv = xpriv_str.parse().unwrap();
 //!
 //! let child_xpriv = xpriv.derive_child(33)?;
-//! let sig: RecoverableSignature = child_xpriv.sign_digest(digest.clone());
+//! let (sig, _recovery_id): (Signature, RecoveryId) = child_xpriv.sign_digest(digest.clone());
 //!
 //! // Signing key types are associated with verifying key types. You can always derive a pubkey
 //! let child_xpub = child_xpriv.verify_key();
-//! child_xpub.verify_digest(digest.clone(), &sig);
+//! child_xpub.verify_digest(digest.clone(), &sig)?;
 //!
 //! MainnetEncoder::xpub_to_base58(&child_xpub)?;
 //! # Ok(())

--- a/bip32/src/prelude.rs
+++ b/bip32/src/prelude.rs
@@ -12,17 +12,16 @@ pub use crate::defaults::*;
 pub use k256;
 pub use k256::{
     ecdsa::{
-        recoverable::Signature as RecoverableSignature,
-        signature::{DigestSigner as _, DigestVerifier as _, Signature as _},
-        Signature, SigningKey, VerifyingKey,
+        signature::{DigestSigner as _, DigestVerifier as _},
+        RecoveryId, Signature, SigningKey, VerifyingKey,
     },
     elliptic_curve::sec1::ToEncodedPoint as _,
 };
 
 /// shortcut for easy usage
-pub fn fingerprint_of(k: &k256::ecdsa::VerifyingKey) -> KeyFingerprint {
+pub fn fingerprint_of(k: &VerifyingKey) -> KeyFingerprint {
     use coins_core::hashes::Digest;
-    let digest = coins_core::hashes::Hash160::digest(k.to_bytes());
+    let digest = coins_core::hashes::Hash160::digest(k.to_sec1_bytes());
     let mut fingerprint = [0u8; 4];
     fingerprint.copy_from_slice(&digest[..4]);
     fingerprint.into()


### PR DESCRIPTION
Upgrade motivated by https://github.com/gakonst/ethers-rs/issues/2158#issuecomment-1462927693.

The new `k256` v0.13 brought two breaking changes for the `bip32` crate:

The [`RecoverableSignature`](https://docs.rs/k256/0.11.6/k256/ecdsa/recoverable/struct.Signature.html) type has been removed which necessitated changes in the `inherit_signer` derive macro.  Following the [upgrade guide,](https://docs.rs/k256/latest/k256/ecdsa/index.html#upgrading-recoverable-signature-code-from-earlier-versions-of-k256) I've replaced the `DigestSigner<D, RecoverableSignature>` implementation with `DigestSigner<D, (Signature, RecoveryId)>` that uses the new [SigningKey::sign_digest_recoverable](https://docs.rs/ecdsa/0.16.0/x86_64-unknown-linux-gnu/ecdsa/signing/struct.SigningKey.html#method.sign_digest_recoverable) method. In order to preserve the recursive structure, I also added a `sign_digest_recoverable` method to the derive macro.

The [`VerifyingKey::to_bytes`](https://docs.rs/k256/0.11.6/k256/ecdsa/struct.VerifyingKey.html#method.to_bytes) method has been renamed to [`VerifyingKey::to_sec1_bytes`](https://docs.rs/ecdsa/latest/ecdsa/struct.VerifyingKey.html#method.to_sec1_bytes) and I made the corresponding  changes in the `inherit_signer` derive macro.