### PR TITLE
ci: run doctests in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -e
 
 cargo build --verbose
 cargo test --verbose --lib
+cargo test --verbose --doc
 
 ### BIP32 ###
 cd bip32


### PR DESCRIPTION
Hey, 

I noticed the doc tests weren't running in the build script, so I added them there. Alternatively, removing the `--lib` flag on line 6 would run them as well, but maybe that would have unintended effects?